### PR TITLE
Update filebeat, add support for specifying k8s-cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 
 MAINTAINER Amanpreet Singh <aps.sids@gmail.com>
 
-ENV FILEBEAT_VERSION 5.3.2
+ENV FILEBEAT_VERSION 5.6.4
 
 RUN apt-get update && \
     apt-get -y install wget && \

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ spec:
             value: myhost.com:5000
           - name: LOG_LEVEL
             value: info
+          - name: K8S_CLUSTER
+            value: my-cluster
           - name: FILEBEAT_HOST
             valueFrom:
                 fieldRef:

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ spec:
             value: myhost.com:5000
           - name: LOG_LEVEL
             value: info
-          - name: K8S_CLUSTER
-            value: my-cluster
+          - name: CLUSTER_NAME
+            value: my_cluster
           - name: FILEBEAT_HOST
             valueFrom:
                 fieldRef:

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -13,6 +13,7 @@ filebeat.prospectors:
   document_type: kube-logs
   fields:
     host: ${FILEBEAT_HOST:${HOSTNAME}}
+    k8s-cluster: ${K8S_CLUSTER}
   fields_under_root: true
 
 output.logstash:

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -13,7 +13,7 @@ filebeat.prospectors:
   document_type: kube-logs
   fields:
     host: ${FILEBEAT_HOST:${HOSTNAME}}
-    k8s-cluster: ${K8S_CLUSTER}
+    cluster_name: ${K8S_CLUSTER:default}
   fields_under_root: true
 
 output.logstash:

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -13,7 +13,7 @@ filebeat.prospectors:
   document_type: kube-logs
   fields:
     host: ${FILEBEAT_HOST:${HOSTNAME}}
-    cluster_name: ${K8S_CLUSTER:default}
+    cluster_name: ${CLUSTER_NAME:default}
   fields_under_root: true
 
 output.logstash:


### PR DESCRIPTION
This upgrades Filebeat to 5.6.4 and adds support for naming the K8S cluster - helpful if one has multiple.